### PR TITLE
Keep moves after forced evo

### DIFF
--- a/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
+++ b/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
@@ -906,21 +906,11 @@ public class TrainerPokemonRandomizer extends Randomizer {
     }
 
     public void createFullyEvolvedPokemon(TrainerPokemon tp) {
-        Species oldSpecies = tp.getSpecies();
-        Species newSpecies = fullyEvolve(oldSpecies);
-        if (newSpecies != oldSpecies) {
+        Species newSpecies = fullyEvolve(tp.getSpecies());
+        if (newSpecies != tp.getSpecies()) {
             tp.setSpecies(newSpecies);
             setFormeForTrainerPokemon(tp, newSpecies);
             tp.setAbilitySlot(getValidAbilitySlotFromOriginal(newSpecies, tp.getAbilitySlot()));
-
-            // If the type of the Pokemon changed through evolution, reset its moves, otherwise keep them
-            Type oldPrimaryType = oldSpecies.getPrimaryType(false);
-            Type oldSecondaryType = oldSpecies.getSecondaryType(false);
-            Type newPrimaryType = newSpecies.getPrimaryType(false);
-            Type newSecondaryType = newSpecies.getSecondaryType(false);
-            if (oldPrimaryType != newPrimaryType || oldSecondaryType != newSecondaryType) {
-                tp.setResetMoves(true);
-            }
         }
     }
 

--- a/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
+++ b/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
@@ -906,11 +906,21 @@ public class TrainerPokemonRandomizer extends Randomizer {
     }
 
     public void createFullyEvolvedPokemon(TrainerPokemon tp) {
-        Species newSpecies = fullyEvolve(tp.getSpecies());
-        if (newSpecies != tp.getSpecies()) {
+        Species oldSpecies = tp.getSpecies();
+        Species newSpecies = fullyEvolve(oldSpecies);
+        if (newSpecies != oldSpecies) {
             tp.setSpecies(newSpecies);
             setFormeForTrainerPokemon(tp, newSpecies);
             tp.setAbilitySlot(getValidAbilitySlotFromOriginal(newSpecies, tp.getAbilitySlot()));
+
+            // If the type of the Pokemon changed through evolution, reset its moves, otherwise keep them
+            Type oldPrimaryType = oldSpecies.getPrimaryType(false);
+            Type oldSecondaryType = oldSpecies.getSecondaryType(false);
+            Type newPrimaryType = newSpecies.getPrimaryType(false);
+            Type newSecondaryType = newSpecies.getSecondaryType(false);
+            if (oldPrimaryType != newPrimaryType || oldSecondaryType != newSecondaryType) {
+                tp.setResetMoves(true);
+            }
         }
     }
 

--- a/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
+++ b/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
@@ -71,7 +71,7 @@ public class TrainerPokemonRandomizer extends Randomizer {
         boolean regularDiversity = settings.isDiverseTypesForRegularTrainers();
 
         // If we get here with TrainersMod UNCHANGED, that means additional Pokemon were
-        // added that needs to be randomized according to the following settings
+        // added that are supposed to be randomized according to the following settings
         if (isUnchanged) {
             keepTypeThemes = true;
             banIrregularAltFormes = true;
@@ -911,7 +911,6 @@ public class TrainerPokemonRandomizer extends Randomizer {
             tp.setSpecies(newSpecies);
             setFormeForTrainerPokemon(tp, newSpecies);
             tp.setAbilitySlot(getValidAbilitySlotFromOriginal(newSpecies, tp.getAbilitySlot()));
-            tp.setResetMoves(true);
         }
     }
 

--- a/test/test/randomizers/TrainerRandomizersTest.java
+++ b/test/test/randomizers/TrainerRandomizersTest.java
@@ -623,7 +623,7 @@ public class TrainerRandomizersTest extends RandomizerTest {
 
     @ParameterizedTest
     @MethodSource("getRomNames")
-    public void forcedEvolutionsOfOriginalPokemonResetMovesIfAndOnlyIfTypeChanged(String romName) {
+    public void forcedEvolutionsDoNotResetMoves(String romName) {
         activateRomHandler(romName);
 
         // Record original species of all trainer Pokemon (for better console output only)

--- a/test/test/randomizers/TrainerRandomizersTest.java
+++ b/test/test/randomizers/TrainerRandomizersTest.java
@@ -626,15 +626,14 @@ public class TrainerRandomizersTest extends RandomizerTest {
     public void forcedEvolutionsOfOriginalPokemonResetMovesIfAndOnlyIfTypeChanged(String romName) {
         activateRomHandler(romName);
 
-        // Record original types of all trainer Pokemon
-        Map<Trainer, List<List<Type>>> originalTypes = new HashMap<>();;
+        // Record original species of all trainer Pokemon (for better console output only)
+        Map<Trainer, List<String>> originalNames = new HashMap<>();
+
         for (Trainer tr : romHandler.getTrainers()) {
-            List<List<Type>> typesBefore = new ArrayList<>();
-            originalTypes.put(tr, typesBefore);
+            List<String> namesBefore = new ArrayList<>();
+            originalNames.put(tr, namesBefore);
             for (TrainerPokemon tp : tr.pokemon) {
-                List<Type> typesOfPokemon = Arrays.asList(tp.getSpecies().getPrimaryType(false),
-                        tp.getSpecies().getSecondaryType(false));
-                typesBefore.add(typesOfPokemon);
+                namesBefore.add(tp.getSpecies().getName());
             }
         }
 
@@ -647,31 +646,11 @@ public class TrainerRandomizersTest extends RandomizerTest {
         // Test
         for (Trainer tr : romHandler.getTrainers()) {
             System.out.println("\n" + tr);
-            List<List<Type>> typesBefore = originalTypes.get(tr);
             for (int k = 0; k<tr.pokemon.size(); k++) {
                 TrainerPokemon tp = tr.pokemon.get(k);
-
-                Species newSpecies = tp.getSpecies();
-                Type newPrimaryType = newSpecies.getPrimaryType(false);
-                Type newSecondaryType = newSpecies.getSecondaryType(false);
-
-                Type oldPrimaryType = typesBefore.get(k).get(0);
-                Type oldSecondaryType = typesBefore.get(k).get(1);
-
-                System.out.println(tp + " : Forced evolution type change: (" + oldPrimaryType + ", " + oldSecondaryType +
-                        ") --> (" + newPrimaryType + ", " + newSecondaryType + ")");
-
-                if (tp.isResetMoves()) {
-                    // Pokemon has to be evolved with a different type
-                    System.out.println("resetMoves = TRUE");
-                    assertTrue(oldPrimaryType != newPrimaryType || oldSecondaryType != newSecondaryType);
-                }
-                else {
-                    // Pokemon has to have the same type as pre randomization (can be different species though)
-                    System.out.println("resetMoves = FALSE");
-                    assertTrue(oldPrimaryType == newPrimaryType && oldSecondaryType == newSecondaryType);
-                }
-
+                System.out.println(originalNames.get(tr).get(k) + "-->" + tp.getSpecies().getName() +
+                        ": resetMoves = " + tp.isResetMoves());
+                assertFalse(tp.isResetMoves());
             }
         }
     }


### PR DESCRIPTION
Implements https://github.com/upr-fvx/universal-pokemon-randomizer-fvx/issues/49

1. Keep pre-evolution moves <s>if type does not change because of the evolution</s>
2. Add unit test validating that the resetMoves flag <s>is true if and only if the pre- and post-evolution have different types</s> is always false

Additional context:
After the feedback in above contribution idea, I decided to only implement something that is a general design decision and would be unaffected by any upcoming improvements to default/better movesets.

* If better movesets are selected, the changes here are irrelevant since all moves are changed anyway.
*  In my opinion, default movesets should only apply to non-deterministic Pokemon (additional Pokemon or randomized Pokemon). A forced evolution is deterministic (at least mostly, Eevee of course has some randomness still) and thus there is no need to change moves in general since the existing moves fit the 'new' Pokemon.

To summarize the idea behind this: 
* If someone does not want better movesets but wants to force evolutions, they likely want end-game trainers to not have under evolved Pokemon but want the experience to be as vanilla as possible.
* <s>However: Besides the Magicarp case, where an evolution without resetMoves will cause an extremely weird Gyarados, an issue was how to handle Eevee, where a forced evolution without move reset would likely leave the Pokemon without any STAB moves. Ultimately, to handle these cases, I went with the suggestion from the linked issue to still reset moves if the type changes.</s>

In the FireRed example, I think this creates good results, e.g.:

Agathas Golbat becomes a Crobat and keeps its moves, which were fine and fitting already:
CONFUSE RAY, POISON FANG, AIR CUTTER, BITE

One of Lances Dragonairs becomes Dragonite and <s>instead of 
SAFEGUARD, HYPER BEAM, OUTRAGE, DRAGONRAGE
it gains a STAB move for 
SAFEGUARD, HYPER BEAM, OUTRAGE, WING ATTACK
</s> keeps its moves