### PR TITLE
Do not throw exception for allowed PC potion replacement

### DIFF
--- a/src/com/dabomstew/pkromio/romhandlers/Gen1RomHandler.java
+++ b/src/com/dabomstew/pkromio/romhandlers/Gen1RomHandler.java
@@ -2353,7 +2353,7 @@ public class Gen1RomHandler extends AbstractGBCRomHandler {
     @Override
     public void setPCPotionItem(Item item) {
         if (romEntry.getIntValue("PCPotionOffset") != 0) {
-            if (item.isAllowed()) {
+            if (!item.isAllowed()) {
                 throw new IllegalArgumentException("item not allowed for PC Potion: " + item.getName());
             }
             writeByte(romEntry.getIntValue("PCPotionOffset"), (byte) (item.getId() & 0xFF));

--- a/src/com/dabomstew/pkromio/romhandlers/Gen3RomHandler.java
+++ b/src/com/dabomstew/pkromio/romhandlers/Gen3RomHandler.java
@@ -4063,7 +4063,7 @@ public class Gen3RomHandler extends AbstractGBRomHandler {
     @Override
     public void setPCPotionItem(Item item) {
         if (romEntry.getIntValue("PCPotionOffset") != 0) {
-            if (item.isAllowed()) {
+            if (!item.isAllowed()) {
                 throw new IllegalArgumentException("item not allowed for PC Potion: " + item.getName());
             }
             writeWord(romEntry.getIntValue("PCPotionOffset"), item.getId());


### PR DESCRIPTION
Fixes last small issue 
from https://github.com/upr-fvx/universal-pokemon-randomizer-fvx/issues/43