### PR TITLE
improve compatibility with more distros

### DIFF
--- a/launcher/launcher_UNIX.sh
+++ b/launcher/launcher_UNIX.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 cd "$( dirname "$0" )"
 java -Xmx4608M -jar UPR-FVX.jar please-use-the-launcher


### PR DESCRIPTION
the distro I use, NixOS, doesn't have a file at `/bin/bash`.
bash isn't needed anyway so compatibility can be improved for free by using regular sh