### PR TITLE
Avoid duplicates might break evolution restrictions

### DIFF
--- a/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
+++ b/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
@@ -493,6 +493,17 @@ public class TrainerPokemonRandomizer extends Randomizer {
             pickFrom = cacheOrReplacement;
         }
 
+        if (!alreadyPlaced.isEmpty()) {
+            // alreadyPlaced can only be non-empty if settings.isTrainersAvoidDuplicate is selected.
+            // Remove species already placed for the current trainer from pool
+            pickFrom = pickFrom.filter(pk -> !alreadyPlaced.contains(pk));
+            // If nothing remains in the pool, add all placed species to the pool again and clear alreadyPlaced
+            if (pickFrom.isEmpty()) {
+                pickFrom.addAll(alreadyPlaced);
+                alreadyPlaced.clear();
+            }
+        }
+
         if (type != null && cachedByType != null) {
             // "Type Themed" settings
             SpeciesSet pokemonOfType;
@@ -560,19 +571,6 @@ public class TrainerPokemonRandomizer extends Randomizer {
                 return cachePick;
             }
             //if we didn't... well, if it's banned anyway, it might as well be from the substitution set
-        }
-
-        if (!alreadyPlaced.isEmpty()) {
-            // alreadyPlaced can only be non-empty if settings.isTrainersAvoidDuplicate is selected.
-            // Remove species already placed for the current trainer from pool
-            pickFrom = pickFrom.filter(pk -> !alreadyPlaced.contains(pk));
-            // If nothing remains in the pool, add all placed species to the pool again and clear alreadyPlaced
-            if (pickFrom.isEmpty()) {
-                // Try again with alreadyPlaced empty and thus allowing duplicates while trying to uphold other contracts.
-                alreadyPlaced.clear();
-                return pickTrainerPokeReplacement(current, level, usePowerLevels, alreadyPlaced, doNotUsePrematureEvos, type, usePlacementHistory,
-                        swapMegaEvos, useInsteadOfCached, evolveAsFarAsLegal, bannedTypes, bannedPokemon);
-            }
         }
 
         return usePowerLevels ?


### PR DESCRIPTION
Bugfix for #162 

If Trainer Pokemon were unchanged and Pokemon were added, it was possible for evolution restrictions to not hold, e.g., even with 'Trainers evolve their Pokemon' and Lances level over Lv 55 in Gen 1, it was possible that Lance might receive a Dragonair as his additional Pokemon.

The reason was that avoid duplicates refills the pool of available Pokemon after the evolution filter were executed. Since Dragonair is one of his original Pokemon, it was possible for Dragonair to be placed.

To fix this, re-call `pickTrainerPokeReplacement` after the `alreadyPlaced` was cleared.

No release note since 'Avoid Duplicates' is unreleased.