### PR TITLE
Fix duplicates for type themed trainers

### DIFF
--- a/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
+++ b/src/com/dabomstew/pkrandom/randomizers/TrainerPokemonRandomizer.java
@@ -570,13 +570,18 @@ public class TrainerPokemonRandomizer extends Randomizer {
             //if we didn't... well, if it's banned anyway, it might as well be from the substitution set
         }
 
+        // To avoid duplicates (if the option is selected) as often as possible, the following has to be the last filter
+        // applied in this method
         if (!alreadyPlaced.isEmpty()) {
-            // alreadyPlaced can only be non-empty if settings.isTrainersAvoidDuplicate is selected.
-            // Remove species already placed for the current trainer from pool
+            // The SpeciesSet alreadyPlaced can only be non-empty if settings.isTrainersAvoidDuplicate is selected.
+            // Determine pool of Species that have not been placed for the current trainer yet.
             SpeciesSet notPlaced = pickFrom.filter(pk -> !alreadyPlaced.contains(pk));
-            // Only update Pool if unplaced Pokemon remain, otherwise accept duplicates
-            if (!notPlaced.isEmpty()) {
+            if (!notPlaced.isEmpty()) { // Only update pool pickFrom if there are unplaced Species left, ...
                 pickFrom = notPlaced;
+            } else { // ... otherwise accept duplicates.
+                // With alreadyPlaced as is, it is guaranteed that notPlaced would be empty for all remaining Pokemon
+                // of the current trainer. Therefore, reset alreadyPlaced to try to minimize number of duplicates.
+                alreadyPlaced.clear();
             }
         }
 


### PR DESCRIPTION
Fixes the issue described in #186.

No release note because feature is not yet released. 

The pool pickFrom is now no longer refilled with alreadyPlaced if no unplaced Species remain but instead pickFrom is only updated if it has already been determined that Species remain. This can (and must) now be the last step again in pickPokeReplacement to avoid issues as solved in #169.