### PR TITLE
Redesign Better Movesets as role-based four-slot construction

### DIFF
--- a/random/src/main/java/com/uprfvx/random/randomizers/TrainerMovesetRandomizer.java
+++ b/random/src/main/java/com/uprfvx/random/randomizers/TrainerMovesetRandomizer.java
@@ -3,10 +3,12 @@ package com.uprfvx.random.randomizers;
 import com.uprfvx.random.Settings;
 import com.uprfvx.romio.constants.AbilityIDs;
 import com.uprfvx.romio.constants.GlobalConstants;
+import com.uprfvx.romio.constants.MoveIDs;
 import com.uprfvx.romio.gamedata.*;
 import com.uprfvx.romio.romhandlers.RomHandler;
 
 import java.util.*;
+import java.util.function.ToDoubleFunction;
 import java.util.stream.Collectors;
 
 public class TrainerMovesetRandomizer extends Randomizer {
@@ -44,233 +46,547 @@ public class TrainerMovesetRandomizer extends Randomizer {
 
                 List<Move> movesAtLevel = getMoveSelectionPoolAtLevel(tp, isCyclicEvolutions);
 
+                Species pk = tp.getSpecies();
+                int ability = hasAbilities ? romHandler.getAbilityForTrainerPokemon(tp) : 0;
+
+                // Strip intrinsically-redundant situational status moves (weather / Trick Room) up front, so they
+                // cannot slip in via a small movepool or the trim / fallback paths that skip the per-slot gate.
+                movesAtLevel.removeIf(mv -> isSituationalStatusRedundant(mv, pk, ability));
+
+                // Some moves are dead weight unless an "enabler" move is also known: Sleep Talk and Snore only act
+                // while the user sleeps (Rest), and Spit Up and Swallow consume Stockpile counters. If a dependent's
+                // enabler is not even in the pool, strip it before it can claim a slot; the post-pass below then
+                // guarantees the dependency even when the enabler is available but goes unpicked.
+                stripUnsupportedDependentMoves(movesAtLevel);
+
+                if (movesAtLevel.isEmpty()) {
+                    // No custom moves to offer (e.g. a low-level rival starter whose selection pool is empty).
+                    // Rather than leave the Pokemon moveless (all-zero slots), let the game assign it its natural
+                    // level-up moveset at ROM-write time.
+                    tp.setResetMoves(true);
+                    continue;
+                }
+
                 movesAtLevel = trimMoveList(tp, movesAtLevel, isOnlyMultiBattles);
 
                 if (movesAtLevel.isEmpty()) {
+                    // trimMoveList already wrote a small (<=4) moveset directly into tp; nothing more to build.
                     continue;
                 }
 
-                double trainerTypeModifier = 1;
-                if (t.isImportant()) {
-                    trainerTypeModifier = 1.5;
-                } else if (t.isBoss()) {
-                    trainerTypeModifier = 2;
-                }
-                double movePoolSizeModifier = movesAtLevel.size() / 10.0;
-                double bonusModifier = trainerTypeModifier * movePoolSizeModifier;
+                int level = tp.getLevel();
+                // Boss & Important trainers get the full STAB + coverage + status + wildcard structure;
+                // Regular trainers skip the status slot (STAB + coverage + wildcard + wildcard).
+                boolean includeStatus = t.isBoss() || t.isImportant();
 
-                double atkSpatkRatioModifier = 0.75;
-                double stabMoveBias = 0.25 * bonusModifier;
-                double hardAbilityMoveBias = 1 * bonusModifier;
-                double softAbilityMoveBias = 0.5 * bonusModifier;
-                double statBias = 0.5 * bonusModifier;
-                double softMoveBias = 0.25 * bonusModifier;
-                double hardMoveBias = 1 * bonusModifier;
-                double softMoveAntiBias = 0.5;
+                List<Move> distinctPool = movesAtLevel.stream().distinct().collect(Collectors.toList());
+                List<Move> picked = new ArrayList<>();
 
-                // Add bias for STAB
-
-                Species pk = tp.getSpecies();
-
-                List<Move> stabMoves = new ArrayList<>(movesAtLevel)
-                        .stream()
-                        .filter(mv -> mv.type == pk.getPrimaryType(false) && mv.category != MoveCategory.STATUS)
-                        .collect(Collectors.toList());
-                Collections.shuffle(stabMoves, random);
-
-                for (int i = 0; i < stabMoveBias * stabMoves.size(); i++) {
-                    int j = i % stabMoves.size();
-                    movesAtLevel.add(stabMoves.get(j));
-                }
-
-                if (pk.getSecondaryType(false) != null) {
-                    stabMoves = new ArrayList<>(movesAtLevel)
-                            .stream()
-                            .filter(mv -> mv.type == pk.getSecondaryType(false) && mv.category != MoveCategory.STATUS)
-                            .collect(Collectors.toList());
-                    Collections.shuffle(stabMoves, random);
-
-                    for (int i = 0; i < stabMoveBias * stabMoves.size(); i++) {
-                        int j = i % stabMoves.size();
-                        movesAtLevel.add(stabMoves.get(j));
+                if (distinctPool.size() <= 4) {
+                    // Too few candidates to be choosy - just take what is available.
+                    picked.addAll(distinctPool);
+                } else {
+                    // Slot 1: a STAB attacking move, base power scaled to the Pokemon's level.
+                    Move stab = pickStabMove(pk, distinctPool, level, picked);
+                    if (stab == null) {
+                        stab = pickBestDamaging(distinctPool, picked);
                     }
-                }
+                    if (stab != null) {
+                        picked.add(stab);
+                    }
 
-                if (hasAbilities) {
-                    movesAtLevel = updateMovesConsideringAbilitySynergies(tp, pk, movesAtLevel, hardAbilityMoveBias, softAbilityMoveBias);
-                }
+                    // Slot 2: a coverage move that hits what the STAB move is walled by.
+                    Move coverage = pickCoverageMove(pk, distinctPool, level,
+                            stab == null ? null : stab.type, picked);
+                    if (coverage == null) {
+                        coverage = pickBestDamaging(distinctPool, picked);
+                    }
+                    if (coverage != null) {
+                        picked.add(coverage);
+                    }
 
-                List<Move> distinctMoveList = movesAtLevel.stream().distinct().collect(Collectors.toList());
-                int movesLeft = distinctMoveList.size();
-
-                if (movesLeft <= 4) {
-
-                    for (int i = 0; i < 4; i++) {
-                        if (i < movesLeft) {
-                            tp.getMoves()[i] = distinctMoveList.get(i).number;
-                        } else {
-                            tp.getMoves()[i] = 0;
+                    // Slot 3 (bosses/important only): a non-redundant status move.
+                    if (includeStatus) {
+                        Move status = pickStatusMove(pk, ability, distinctPool, picked);
+                        if (status == null) {
+                            status = pickBestDamaging(distinctPool, picked);
                         }
-                    }
-                    continue;
-                }
-
-                movesAtLevel = updateMovesConsideringStatSynergies(pk, movesAtLevel, statBias);
-
-                distinctMoveList = movesAtLevel.stream().distinct().collect(Collectors.toList());
-                movesLeft = distinctMoveList.size();
-
-                if (movesLeft <= 4) {
-
-                    for (int i = 0; i < 4; i++) {
-                        if (i < movesLeft) {
-                            tp.getMoves()[i] = distinctMoveList.get(i).number;
-                        } else {
-                            tp.getMoves()[i] = 0;
-                        }
-                    }
-                    continue;
-                }
-
-                // Add bias for atk/spatk ratio
-
-                double atkSpatkRatio = getAtkSpatkRatio(tp, pk);
-
-                List<Move> physicalMoves = new ArrayList<>(movesAtLevel)
-                        .stream()
-                        .filter(mv -> mv.category == MoveCategory.PHYSICAL).collect(Collectors.toList());
-                List<Move> specialMoves = new ArrayList<>(movesAtLevel)
-                        .stream()
-                        .filter(mv -> mv.category == MoveCategory.SPECIAL).collect(Collectors.toList());
-
-                if (atkSpatkRatio < 1 && !specialMoves.isEmpty()) {
-                    atkSpatkRatio = 1 / atkSpatkRatio;
-                    double acceptedRatio = atkSpatkRatioModifier * atkSpatkRatio;
-                    int additionalMoves = (int) (physicalMoves.size() * acceptedRatio) - specialMoves.size();
-                    for (int i = 0; i < additionalMoves; i++) {
-                        Move mv = specialMoves.get(random.nextInt(specialMoves.size()));
-                        movesAtLevel.add(mv);
-                    }
-                } else if (!physicalMoves.isEmpty()) {
-                    double acceptedRatio = atkSpatkRatioModifier * atkSpatkRatio;
-                    int additionalMoves = (int) (specialMoves.size() * acceptedRatio) - physicalMoves.size();
-                    for (int i = 0; i < additionalMoves; i++) {
-                        Move mv = physicalMoves.get(random.nextInt(physicalMoves.size()));
-                        movesAtLevel.add(mv);
-                    }
-                }
-
-                // Pick moves
-
-                List<Move> pickedMoves = new ArrayList<>();
-
-                for (int i = 1; i <= 4; i++) {
-                    Move move;
-                    List<Move> pickFrom;
-
-                    if (i == 1) {
-                        pickFrom = movesAtLevel
-                                .stream()
-                                .filter(mv -> mv.isGoodDamaging(romHandler.getPerfectAccuracy()))
-                                .collect(Collectors.toList());
-                        if (pickFrom.isEmpty()) {
-                            pickFrom = movesAtLevel;
-                        }
-                    } else {
-                        pickFrom = movesAtLevel;
-                    }
-
-                    if (i == 4) {
-                        List<Move> requiresOtherMove = movesAtLevel
-                                .stream()
-                                .filter(mv -> GlobalConstants.requiresOtherMove.contains(mv.number))
-                                .distinct().collect(Collectors.toList());
-
-                        for (Move dependentMove : requiresOtherMove) {
-                            boolean hasRequiredMove = false;
-                            for (Move requiredMove : MoveSynergy.requiresOtherMove(dependentMove, movesAtLevel)) {
-                                if (pickedMoves.contains(requiredMove)) {
-                                    hasRequiredMove = true;
-                                    break;
-                                }
-                            }
-                            if (!hasRequiredMove) {
-                                movesAtLevel.removeAll(Collections.singletonList(dependentMove));
-                            }
+                        if (status != null) {
+                            picked.add(status);
                         }
                     }
 
-                    move = pickFrom.get(random.nextInt(pickFrom.size()));
-                    pickedMoves.add(move);
-
-                    if (i == 4) {
-                        break;
-                    }
-
-                    movesAtLevel.removeAll(Collections.singletonList(move));
-
-                    movesAtLevel.removeAll(MoveSynergy.getHardMoveAntiSynergy(move, movesAtLevel));
-
-                    distinctMoveList = movesAtLevel.stream().distinct().collect(Collectors.toList());
-                    movesLeft = distinctMoveList.size();
-
-                    if (movesLeft <= (4 - i)) {
-                        pickedMoves.addAll(distinctMoveList);
-                        break;
-                    }
-
-                    List<Move> hardMoveSynergyList = MoveSynergy.getMoveSynergy(
-                            move,
-                            movesAtLevel,
-                            romHandler.generationOfPokemon());
-                    Collections.shuffle(hardMoveSynergyList, random);
-                    for (int j = 0; j < hardMoveBias * hardMoveSynergyList.size(); j++) {
-                        int k = j % hardMoveSynergyList.size();
-                        movesAtLevel.add(hardMoveSynergyList.get(k));
-                    }
-
-                    List<Move> softMoveSynergyList = MoveSynergy.getSoftMoveSynergy(
-                            move,
-                            movesAtLevel,
-                            romHandler.getTypeTable());
-                    Collections.shuffle(softMoveSynergyList, random);
-                    for (int j = 0; j < softMoveBias * softMoveSynergyList.size(); j++) {
-                        int k = j % softMoveSynergyList.size();
-                        movesAtLevel.add(softMoveSynergyList.get(k));
-                    }
-
-                    List<Move> softMoveAntiSynergyList = MoveSynergy.getSoftMoveAntiSynergy(move, movesAtLevel);
-                    Collections.shuffle(softMoveAntiSynergyList, random);
-                    for (int j = 0; j < softMoveAntiBias * softMoveAntiSynergyList.size(); j++) {
-                        distinctMoveList = movesAtLevel.stream().distinct().collect(Collectors.toList());
-                        if (distinctMoveList.size() <= (4 - i)) {
-                            break;
-                        }
-                        int k = j % softMoveAntiSynergyList.size();
-                        movesAtLevel.remove(softMoveAntiSynergyList.get(k));
-                    }
-
-                    distinctMoveList = movesAtLevel.stream().distinct().collect(Collectors.toList());
-                    movesLeft = distinctMoveList.size();
-
-                    if (movesLeft <= (4 - i)) {
-                        pickedMoves.addAll(distinctMoveList);
-                        break;
-                    }
+                    // Remaining slots: wildcard picks reusing the existing synergy-weighted logic.
+                    fillWildcardMoves(t, tp, pk, ability, distinctPool, picked);
                 }
 
-                int movesPicked = pickedMoves.size();
+                // Enabler-dependency guarantee across every slot: drop any dependent whose enabler did not make the
+                // final set (Snore/Sleep Talk without Rest, Spit Up/Swallow without Stockpile), then backfill with
+                // the next-best damaging move.
+                enforceEnablerDependencies(picked, distinctPool);
 
                 for (int i = 0; i < 4; i++) {
-                    if (i < movesPicked) {
-                        tp.getMoves()[i] = pickedMoves.get(i).number;
-                    } else {
-                        tp.getMoves()[i] = 0;
-                    }
+                    tp.getMoves()[i] = i < picked.size() ? picked.get(i).number : 0;
                 }
             }
         }
         changesMade = true;
+    }
+
+    // ===== Role-based moveset construction (custom Better Movesets redesign) ==========================
+    // Boss/Important: STAB + Coverage + Status + Wildcard. Regular: STAB + Coverage + Wildcard + Wildcard.
+    // Any slot that cannot be filled falls back to the next-best damaging move, so every mon gets 4 moves.
+
+    private static final double STAB_LEVEL_POWER_MULTIPLIER = 3.0;
+    private static final double COVERAGE_BLIND_SPOT_BONUS = 2.0;
+    private static final int TRICK_ROOM_MAX_SPEED = 60;
+
+    // Weather moves are only worth running if the Pokemon benefits from that weather, and are pointless
+    // (redundant) if the Pokemon's own ability already sets it.
+    private static final Set<Integer> RAIN_BENEFIT_ABILITIES = Set.of(
+            AbilityIDs.swiftSwim, AbilityIDs.rainDish, AbilityIDs.drySkin, AbilityIDs.hydration);
+    private static final Set<Integer> RAIN_SETTER_ABILITIES = Set.of(
+            AbilityIDs.drizzle, AbilityIDs.primordialSea);
+    private static final Set<Integer> SUN_BENEFIT_ABILITIES = Set.of(
+            AbilityIDs.chlorophyll, AbilityIDs.solarPower, AbilityIDs.leafGuard, AbilityIDs.flowerGift, AbilityIDs.harvest);
+    private static final Set<Integer> SUN_SETTER_ABILITIES = Set.of(
+            AbilityIDs.drought, AbilityIDs.desolateLand);
+    private static final Set<Integer> SAND_BENEFIT_ABILITIES = Set.of(
+            AbilityIDs.sandVeil, AbilityIDs.sandRush, AbilityIDs.sandForce);
+    private static final Set<Integer> SAND_SETTER_ABILITIES = Set.of(AbilityIDs.sandStream);
+    private static final Set<Integer> HAIL_BENEFIT_ABILITIES = Set.of(
+            AbilityIDs.snowCloak, AbilityIDs.iceBody, AbilityIDs.slushRush);
+    private static final Set<Integer> HAIL_SETTER_ABILITIES = Set.of(AbilityIDs.snowWarning);
+
+    // Moves that accomplish nothing unless an "enabler" move is also known: Snore and Sleep Talk only act while the
+    // user sleeps (Rest), and Spit Up and Swallow consume Stockpile counters. Each may be selected only when its
+    // enabler is present in the same moveset. Maps dependent move -> its required enabler.
+    private static final Map<Integer, Integer> DEPENDENT_MOVE_ENABLERS = Map.of(
+            MoveIDs.snore, MoveIDs.rest,
+            MoveIDs.sleepTalk, MoveIDs.rest,
+            MoveIDs.spitUp, MoveIDs.stockpile,
+            MoveIDs.swallow, MoveIDs.stockpile);
+
+    // A move that can fill an attacking slot (STAB or coverage): a real, level-appropriate damaging move.
+    private boolean isAttackSlotEligible(Move mv, int level) {
+        if (mv == null || mv.category == MoveCategory.STATUS || mv.power <= 1) {
+            return false;
+        }
+        if (mv.power * mv.hitCount > level * STAB_LEVEL_POWER_MULTIPLIER) {
+            return false;
+        }
+        if (GlobalConstants.badStrongMoves.contains(mv.number)) {
+            return false;
+        }
+        return mv.isGoodDamaging(romHandler.getPerfectAccuracy())
+                || GlobalConstants.goodWeakMoves.contains(mv.number);
+    }
+
+    // Slot 1: a STAB attacking move within the level power band, weighted toward stronger moves.
+    private Move pickStabMove(Species pk, List<Move> pool, int level, List<Move> exclude) {
+        Type t1 = pk.getPrimaryType(false);
+        Type t2 = pk.getSecondaryType(false);
+        List<Move> candidates = pool.stream()
+                .filter(mv -> !exclude.contains(mv))
+                .filter(mv -> mv.type == t1 || (t2 != null && mv.type == t2))
+                .filter(mv -> isAttackSlotEligible(mv, level))
+                .collect(Collectors.toList());
+        if (candidates.isEmpty()) {
+            // Fall back to the strongest STAB move even if it breaks the level ceiling.
+            candidates = pool.stream()
+                    .filter(mv -> !exclude.contains(mv))
+                    .filter(mv -> mv.category != MoveCategory.STATUS && mv.power > 1)
+                    .filter(mv -> mv.type == t1 || (t2 != null && mv.type == t2))
+                    .collect(Collectors.toList());
+        }
+        return weightedPick(candidates, mv -> mv.power * mv.hitCount);
+    }
+
+    // Slot 2: a coverage move hitting a type that resists the STAB move; SE-gated, blind-spot-weighted.
+    private Move pickCoverageMove(Species pk, List<Move> pool, int level, Type stabType, List<Move> exclude) {
+        if (stabType == null) {
+            return null;
+        }
+        TypeTable tt = romHandler.getTypeTable();
+        if (!tt.getTypes().contains(stabType)) {
+            return null;
+        }
+        Set<Type> holes = new HashSet<>(tt.notVeryEffectiveWhenAttacking(stabType));
+        holes.addAll(tt.immuneWhenAttacking(stabType));
+        Set<Type> blindSpots = computeBlindSpots(pk, tt, holes);
+
+        List<Move> eligible = pool.stream()
+                .filter(mv -> !exclude.contains(mv))
+                .filter(mv -> mv.type != stabType)
+                .filter(mv -> isAttackSlotEligible(mv, level))
+                .filter(mv -> tt.getTypes().contains(mv.type))
+                .filter(mv -> coversAny(tt, mv.type, holes, false))
+                .collect(Collectors.toList());
+        if (eligible.isEmpty()) {
+            return null;
+        }
+        // Prefer super-effective coverage; only fall back to merely-neutral coverage if none is SE.
+        List<Move> superEffective = eligible.stream()
+                .filter(mv -> coversAny(tt, mv.type, holes, true))
+                .collect(Collectors.toList());
+        List<Move> chosenSet = superEffective.isEmpty() ? eligible : superEffective;
+        return weightedPick(chosenSet, mv -> {
+            double weight = mv.power * mv.hitCount;
+            if (coversAny(tt, mv.type, blindSpots, false)) {
+                weight *= COVERAGE_BLIND_SPOT_BONUS;
+            }
+            return weight;
+        });
+    }
+
+    // The Pokemon's true offensive blind spots: types resisting BOTH of its types (== STAB holes if mono-type).
+    private Set<Type> computeBlindSpots(Species pk, TypeTable tt, Set<Type> stabHoles) {
+        Type t1 = pk.getPrimaryType(false);
+        Type t2 = pk.getSecondaryType(false);
+        if (t2 == null || t1 == t2) {
+            return stabHoles;
+        }
+        Set<Type> h1 = new HashSet<>(tt.notVeryEffectiveWhenAttacking(t1));
+        h1.addAll(tt.immuneWhenAttacking(t1));
+        Set<Type> h2 = new HashSet<>(tt.notVeryEffectiveWhenAttacking(t2));
+        h2.addAll(tt.immuneWhenAttacking(t2));
+        h1.retainAll(h2);
+        return h1;
+    }
+
+    // Does a move of attackType hit at least one of the given defending types for the required strength?
+    private boolean coversAny(TypeTable tt, Type attackType, Set<Type> defenders, boolean superEffectiveOnly) {
+        for (Type d : defenders) {
+            if (!tt.getTypes().contains(d)) {
+                continue;
+            }
+            Effectiveness eff = tt.getEffectiveness(attackType, d);
+            if (superEffectiveOnly) {
+                if (eff == Effectiveness.DOUBLE) {
+                    return true;
+                }
+            } else if (eff == Effectiveness.NEUTRAL || eff == Effectiveness.DOUBLE) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Slot 3: a non-redundant good status move, synergy-weighted to suit the Pokemon.
+    private Move pickStatusMove(Species pk, int ability, List<Move> pool, List<Move> picked) {
+        List<Move> candidates = pool.stream()
+                .filter(mv -> !picked.contains(mv))
+                .filter(mv -> mv.category == MoveCategory.STATUS)
+                .filter(mv -> GlobalConstants.goodStatusMoves.contains(mv.number))
+                .filter(mv -> !GlobalConstants.uselessMoves.contains(mv.number))
+                .filter(mv -> !isRedundantStatusMove(mv, pk, ability, picked))
+                .collect(Collectors.toList());
+        if (candidates.isEmpty()) {
+            return null;
+        }
+        Set<Integer> synergy = MoveSynergy.getStatMoveSynergy(pk, candidates)
+                .stream().map(mv -> mv.number).collect(Collectors.toSet());
+        return weightedPick(candidates, mv -> synergy.contains(mv.number) ? 3.0 : 1.0);
+    }
+
+    // Global fallback for any unfillable slot: the strongest available damaging move.
+    private Move pickBestDamaging(List<Move> pool, List<Move> exclude) {
+        List<Move> candidates = pool.stream()
+                .filter(mv -> !exclude.contains(mv))
+                .filter(mv -> mv.category != MoveCategory.STATUS && mv.power > 1)
+                .collect(Collectors.toList());
+        return weightedPick(candidates, mv -> mv.power * mv.hitCount);
+    }
+
+    // Situational status moves whose payoff can never apply to this Pokemon based on intrinsic traits only
+    // (type / ability / speed). Safe to strip from the movepool before any slot logic runs, so they cannot
+    // leak in via a small movepool, the trim path, or a damaging fallback.
+    private boolean isSituationalStatusRedundant(Move mv, Species pk, int ability) {
+        switch (mv.number) {
+            case MoveIDs.rainDance:
+                if (RAIN_SETTER_ABILITIES.contains(ability)) {
+                    return true;
+                }
+                return !(hasType(pk, Type.WATER) || RAIN_BENEFIT_ABILITIES.contains(ability));
+            case MoveIDs.sunnyDay:
+                if (SUN_SETTER_ABILITIES.contains(ability)) {
+                    return true;
+                }
+                return !(hasType(pk, Type.FIRE) || SUN_BENEFIT_ABILITIES.contains(ability));
+            case MoveIDs.sandstorm:
+                if (SAND_SETTER_ABILITIES.contains(ability)) {
+                    return true;
+                }
+                return !(hasType(pk, Type.ROCK) || hasType(pk, Type.GROUND) || hasType(pk, Type.STEEL)
+                        || SAND_BENEFIT_ABILITIES.contains(ability));
+            case MoveIDs.hail:
+                if (HAIL_SETTER_ABILITIES.contains(ability)) {
+                    return true;
+                }
+                return !(hasType(pk, Type.ICE) || HAIL_BENEFIT_ABILITIES.contains(ability));
+            case MoveIDs.trickRoom:
+                return pk.getSpeed() > TRICK_ROOM_MAX_SPEED;
+            default:
+                return false;
+        }
+    }
+
+    // A status move is redundant when its situational payoff cannot apply, or a stat boost it grants is wasted.
+    private boolean isRedundantStatusMove(Move mv, Species pk, int ability, List<Move> picked) {
+        if (isSituationalStatusRedundant(mv, pk, ability)) {
+            return true;
+        }
+
+        // Stat-boost gate (inclusive): an Attack-only booster needs >=1 physical move already picked;
+        // a Sp.Atk-only booster needs >=1 special move. Boosters raising both are never gated.
+        boolean boostsAtk = raisesUserAttack(mv);
+        boolean boostsSpAtk = raisesUserSpecialAttack(mv);
+        if (boostsAtk && !boostsSpAtk) {
+            return !hasCategory(picked, MoveCategory.PHYSICAL);
+        }
+        if (boostsSpAtk && !boostsAtk) {
+            return !hasCategory(picked, MoveCategory.SPECIAL);
+        }
+        return false;
+    }
+
+    // Remaining slots: reuse the existing synergy-weighted pick + anti-synergy removal, but never pick a
+    // redundant status move (so e.g. Spinarak never rolls Sunny Day and powers up the Fire moves it fears).
+    private void fillWildcardMoves(Trainer t, TrainerPokemon tp, Species pk, int ability,
+                                   List<Move> pool, List<Move> picked) {
+        if (picked.size() >= 4) {
+            return;
+        }
+
+        List<Move> working = new ArrayList<>();
+        for (Move mv : pool) {
+            if (picked.contains(mv)) {
+                continue;
+            }
+            if (mv.category == MoveCategory.STATUS && isRedundantStatusMove(mv, pk, ability, picked)) {
+                continue;
+            }
+            working.add(mv);
+        }
+
+        double trainerTypeModifier = t.isImportant() ? 1.5 : (t.isBoss() ? 2 : 1);
+        double bonusModifier = trainerTypeModifier * (working.size() / 10.0);
+        double stabMoveBias = 0.25 * bonusModifier;
+        double hardAbilityMoveBias = 1 * bonusModifier;
+        double softAbilityMoveBias = 0.5 * bonusModifier;
+        double statBias = 0.5 * bonusModifier;
+        double softMoveBias = 0.25 * bonusModifier;
+        double hardMoveBias = 1 * bonusModifier;
+        double softMoveAntiBias = 0.5;
+
+        // Re-apply the existing pool biases (STAB, ability, stat, atk/spatk ratio) to the wildcard pool.
+        List<Move> stab1 = working.stream()
+                .filter(mv -> mv.type == pk.getPrimaryType(false) && mv.category != MoveCategory.STATUS)
+                .collect(Collectors.toList());
+        addCopies(working, stab1, stabMoveBias);
+        if (pk.getSecondaryType(false) != null) {
+            List<Move> stab2 = working.stream()
+                    .filter(mv -> mv.type == pk.getSecondaryType(false) && mv.category != MoveCategory.STATUS)
+                    .collect(Collectors.toList());
+            addCopies(working, stab2, stabMoveBias);
+        }
+        if (hasAbilities) {
+            working = updateMovesConsideringAbilitySynergies(tp, pk, working, hardAbilityMoveBias, softAbilityMoveBias);
+        }
+        working = updateMovesConsideringStatSynergies(pk, working, statBias);
+
+        double atkSpatkRatioModifier = 0.75;
+        double atkSpatkRatio = getAtkSpatkRatio(tp, pk);
+        List<Move> physicalMoves = working.stream()
+                .filter(mv -> mv.category == MoveCategory.PHYSICAL).collect(Collectors.toList());
+        List<Move> specialMoves = working.stream()
+                .filter(mv -> mv.category == MoveCategory.SPECIAL).collect(Collectors.toList());
+        if (atkSpatkRatio < 1 && !specialMoves.isEmpty()) {
+            atkSpatkRatio = 1 / atkSpatkRatio;
+            int additionalMoves = (int) (physicalMoves.size() * atkSpatkRatioModifier * atkSpatkRatio) - specialMoves.size();
+            for (int i = 0; i < additionalMoves; i++) {
+                working.add(specialMoves.get(random.nextInt(specialMoves.size())));
+            }
+        } else if (!physicalMoves.isEmpty()) {
+            int additionalMoves = (int) (specialMoves.size() * atkSpatkRatioModifier * atkSpatkRatio) - physicalMoves.size();
+            for (int i = 0; i < additionalMoves; i++) {
+                working.add(physicalMoves.get(random.nextInt(physicalMoves.size())));
+            }
+        }
+
+        // Seed move-to-move synergy from the already-chosen role moves, so wildcards complement them.
+        for (Move rolePick : new ArrayList<>(picked)) {
+            working.removeAll(MoveSynergy.getHardMoveAntiSynergy(rolePick, working));
+            addCopies(working, MoveSynergy.getMoveSynergy(rolePick, working, romHandler.generationOfPokemon()), hardMoveBias);
+            addCopies(working, MoveSynergy.getSoftMoveSynergy(rolePick, working, romHandler.getTypeTable()), softMoveBias);
+        }
+
+        while (picked.size() < 4) {
+            List<Move> distinct = eligibleWildcards(working, pk, ability, picked);
+            int slotsLeft = 4 - picked.size();
+            if (distinct.isEmpty()) {
+                break;
+            }
+            if (distinct.size() <= slotsLeft) {
+                picked.addAll(distinct);
+                break;
+            }
+            // On the last slot, drop moves that need a partner move we did not pick (e.g. Spit Up).
+            if (slotsLeft == 1) {
+                for (Move dependent : new ArrayList<>(distinct)) {
+                    if (!GlobalConstants.requiresOtherMove.contains(dependent.number)) {
+                        continue;
+                    }
+                    boolean hasRequired = false;
+                    for (Move required : MoveSynergy.requiresOtherMove(dependent, working)) {
+                        if (picked.contains(required)) {
+                            hasRequired = true;
+                            break;
+                        }
+                    }
+                    if (!hasRequired) {
+                        working.removeAll(Collections.singletonList(dependent));
+                    }
+                }
+                distinct = eligibleWildcards(working, pk, ability, picked);
+                if (distinct.isEmpty()) {
+                    break;
+                }
+                if (distinct.size() <= slotsLeft) {
+                    picked.addAll(distinct);
+                    break;
+                }
+            }
+
+            Move move = distinct.get(random.nextInt(distinct.size()));
+            picked.add(move);
+            if (picked.size() >= 4) {
+                break;
+            }
+
+            working.removeAll(Collections.singletonList(move));
+            working.removeAll(MoveSynergy.getHardMoveAntiSynergy(move, working));
+            addCopies(working, MoveSynergy.getMoveSynergy(move, working, romHandler.generationOfPokemon()), hardMoveBias);
+            addCopies(working, MoveSynergy.getSoftMoveSynergy(move, working, romHandler.getTypeTable()), softMoveBias);
+
+            List<Move> softAnti = MoveSynergy.getSoftMoveAntiSynergy(move, working);
+            Collections.shuffle(softAnti, random);
+            int softAntiCount = (int) (softMoveAntiBias * softAnti.size());
+            for (int j = 0; j < softAntiCount; j++) {
+                if (eligibleWildcards(working, pk, ability, picked).size() <= (4 - picked.size())) {
+                    break;
+                }
+                working.remove(softAnti.get(j % softAnti.size()));
+            }
+        }
+    }
+
+    // The distinct, currently-pickable wildcard moves (excludes already-picked and redundant status moves).
+    private List<Move> eligibleWildcards(List<Move> working, Species pk, int ability, List<Move> picked) {
+        return working.stream()
+                .filter(mv -> !picked.contains(mv))
+                .filter(mv -> !(mv.category == MoveCategory.STATUS && isRedundantStatusMove(mv, pk, ability, picked)))
+                .distinct()
+                .collect(Collectors.toList());
+    }
+
+    // Adds `factor * toAdd.size()` copies of the given moves into the pool (higher weight in later picks).
+    private void addCopies(List<Move> pool, List<Move> toAdd, double factor) {
+        if (toAdd.isEmpty() || factor <= 0) {
+            return;
+        }
+        Collections.shuffle(toAdd, random);
+        int count = (int) (factor * toAdd.size());
+        for (int i = 0; i < count; i++) {
+            pool.add(toAdd.get(i % toAdd.size()));
+        }
+    }
+
+    // Weighted-random selection over a list, probability proportional to weightFn (>=0). Null if empty.
+    private Move weightedPick(List<Move> candidates, ToDoubleFunction<Move> weightFn) {
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+        double total = 0;
+        for (Move mv : candidates) {
+            total += Math.max(0.0, weightFn.applyAsDouble(mv));
+        }
+        if (total <= 0) {
+            return candidates.get(random.nextInt(candidates.size()));
+        }
+        double r = random.nextDouble() * total;
+        for (Move mv : candidates) {
+            r -= Math.max(0.0, weightFn.applyAsDouble(mv));
+            if (r <= 0) {
+                return mv;
+            }
+        }
+        return candidates.get(candidates.size() - 1);
+    }
+
+    private static boolean hasType(Species pk, Type type) {
+        return pk.getPrimaryType(false) == type || pk.getSecondaryType(false) == type;
+    }
+
+    // Removes enabler-dependent moves whose enabler is absent from the pool, so they can never claim a slot.
+    private static void stripUnsupportedDependentMoves(List<Move> pool) {
+        Set<Integer> present = new HashSet<>();
+        for (Move mv : pool) {
+            present.add(mv.number);
+        }
+        pool.removeIf(mv -> {
+            Integer enabler = DEPENDENT_MOVE_ENABLERS.get(mv.number);
+            return enabler != null && !present.contains(enabler);
+        });
+    }
+
+    // Final cross-slot guarantee: drop any dependent whose enabler did not make the chosen set, then backfill to
+    // four with the next-best damaging move. The backfill pool excludes every dependent, or pickBestDamaging could
+    // re-select the move just removed (Snore and Spit Up are themselves valid damaging moves).
+    private void enforceEnablerDependencies(List<Move> picked, List<Move> distinctPool) {
+        Set<Integer> pickedNumbers = new HashSet<>();
+        for (Move mv : picked) {
+            pickedNumbers.add(mv.number);
+        }
+        boolean removed = picked.removeIf(mv -> {
+            Integer enabler = DEPENDENT_MOVE_ENABLERS.get(mv.number);
+            return enabler != null && !pickedNumbers.contains(enabler);
+        });
+        if (!removed) {
+            return;
+        }
+        List<Move> backfillPool = distinctPool.stream()
+                .filter(mv -> !DEPENDENT_MOVE_ENABLERS.containsKey(mv.number))
+                .collect(Collectors.toList());
+        Move fill;
+        while (picked.size() < 4 && (fill = pickBestDamaging(backfillPool, picked)) != null) {
+            picked.add(fill);
+        }
+    }
+
+    private static boolean hasCategory(List<Move> moves, MoveCategory category) {
+        for (Move mv : moves) {
+            if (mv.category == category) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean raisesOwnStat(Move mv) {
+        return mv.statChangeMoveType == StatChangeMoveType.NO_DAMAGE_USER
+                || mv.statChangeMoveType == StatChangeMoveType.DAMAGE_USER;
+    }
+
+    private static boolean raisesUserAttack(Move mv) {
+        return raisesOwnStat(mv) && (mv.hasSpecificStatChange(StatChangeType.ATTACK, true)
+                || mv.hasSpecificStatChange(StatChangeType.ALL, true));
+    }
+
+    private static boolean raisesUserSpecialAttack(Move mv) {
+        return raisesOwnStat(mv) && (mv.hasSpecificStatChange(StatChangeType.SPECIAL_ATTACK, true)
+                || mv.hasSpecificStatChange(StatChangeType.SPECIAL, true)
+                || mv.hasSpecificStatChange(StatChangeType.ALL, true));
     }
 
     private List<Move> updateMovesConsideringAbilitySynergies(TrainerPokemon tp, Species pk, List<Move> movesAtLevel, double hardAbilityMoveBias, double softAbilityMoveBias) {

--- a/random/src/test/java/com/uprfvx/random/randomizers/BetterMovesetsRandomizerTest.java
+++ b/random/src/test/java/com/uprfvx/random/randomizers/BetterMovesetsRandomizerTest.java
@@ -1,0 +1,268 @@
+package com.uprfvx.random.randomizers;
+
+import com.uprfvx.random.Settings;
+import com.uprfvx.romio.constants.AbilityIDs;
+import com.uprfvx.romio.constants.MoveIDs;
+import com.uprfvx.romio.gamedata.GenRestrictions;
+import com.uprfvx.romio.gamedata.Move;
+import com.uprfvx.romio.gamedata.Species;
+import com.uprfvx.romio.gamedata.Trainer;
+import com.uprfvx.romio.gamedata.TrainerPokemon;
+import com.uprfvx.romio.gamedata.Type;
+import com.uprfvx.romio.romhandlers.Generation;
+import com.uprfvx.romio.romhandlers.RomHandler;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * ROM-driven validation for the custom four-slot Better Movesets redesign.
+ * <p>
+ * Named to match the {@code *Randomizer*Test} filter so it runs under the {@code testROMs} Gradle task (which
+ * sets {@code romsPath} and a 4 GB heap). It does NOT extend {@link RandomizerTest}, so it does not trigger the
+ * load-every-ROM {@code @BeforeAll}; instead it loads each ROM in {@code roms/} itself, by content.
+ * <pre>{@code  ./gradlew.bat :random:testROMs --tests "*BetterMovesets*" }</pre>
+ * Runs Better Movesets on each ROM, prints sample movesets, and asserts the redesign's invariants. Skips itself
+ * if no loadable ROM is present.
+ */
+public class BetterMovesetsRandomizerTest {
+
+    // 3DS retail dumps are multi-GB. Decrypted ones ARE loadable: the NCCH handler reads via RandomAccessFile
+    // and only pulls the GARC archives it needs into memory, so the ROM's file size never lands in the heap.
+    // Cap generously (above the largest retail cart) so decrypted Gen 6/7 ROMs run; genuinely unloadable files
+    // still get skipped gracefully by tryLoad returning null.
+    private static final long MAX_ROM_BYTES = 6L * 1024 * 1024 * 1024;
+    private static final double UBIQUITOUS_RATE = 0.20;
+    private static final int SAMPLE_MOVESETS_PER_ROM = 6;
+
+    private static final Set<Integer> RAIN_ABILITIES = Set.of(
+            AbilityIDs.swiftSwim, AbilityIDs.rainDish, AbilityIDs.drySkin, AbilityIDs.hydration,
+            AbilityIDs.drizzle, AbilityIDs.primordialSea);
+    private static final Set<Integer> SUN_ABILITIES = Set.of(
+            AbilityIDs.chlorophyll, AbilityIDs.solarPower, AbilityIDs.leafGuard, AbilityIDs.flowerGift,
+            AbilityIDs.harvest, AbilityIDs.drought, AbilityIDs.desolateLand);
+    private static final Set<Integer> SAND_ABILITIES = Set.of(
+            AbilityIDs.sandVeil, AbilityIDs.sandRush, AbilityIDs.sandForce, AbilityIDs.sandStream);
+    private static final Set<Integer> HAIL_ABILITIES = Set.of(
+            AbilityIDs.snowCloak, AbilityIDs.iceBody, AbilityIDs.slushRush, AbilityIDs.snowWarning);
+
+    @Test
+    public void inspectBetterMovesets() {
+        String romsDir = System.getProperty("romsPath");
+        assumeTrue(romsDir != null, "romsPath not set");
+        File dir = new File(romsDir);
+        assumeTrue(dir.isDirectory(), "roms dir missing: " + romsDir);
+
+        File[] files = dir.listFiles();
+        assumeTrue(files != null && files.length > 0, "roms dir empty: " + romsDir);
+        List<File> candidates = new ArrayList<>(Arrays.asList(files));
+        candidates.sort(Comparator.comparingLong(File::length)); // small/fast ROMs first
+
+        int loaded = 0;
+        List<String> failures = new ArrayList<>();
+        for (File f : candidates) {
+            if (!f.isFile() || f.getName().equalsIgnoreCase("readme.txt")) {
+                continue;
+            }
+            if (f.length() > MAX_ROM_BYTES) {
+                System.out.printf("SKIP (%.1f GB, too large - likely encrypted 3DS dump): %s%n",
+                        f.length() / 1024.0 / 1024 / 1024, f.getName());
+                continue;
+            }
+            RomHandler rh = tryLoad(f.getAbsolutePath());
+            if (rh == null) {
+                System.out.println("SKIP (not loadable): " + f.getName());
+                continue;
+            }
+            loaded++;
+            failures.addAll(checkOneRom(rh, f.getName()));
+        }
+
+        assumeTrue(loaded > 0, "No loadable ROM found in " + romsDir);
+        assertTrue(failures.isEmpty(),
+                "Better Movesets invariant failures (" + failures.size() + "):\n  " + String.join("\n  ", failures));
+        System.out.println("\n=== All invariants held across " + loaded + " ROM(s). ===");
+    }
+
+    private List<String> checkOneRom(RomHandler romHandler, String romName) {
+        romHandler.getRestrictedSpeciesService().setRestrictions(new GenRestrictions());
+        int gen = romHandler.generationOfPokemon();
+        System.out.println("\n================ " + romName + " (gen " + gen + ") ================");
+
+        Settings s = new Settings();
+        s.setBetterBossTrainerMovesets(true);
+        s.setBetterImportantTrainerMovesets(true);
+        s.setBetterRegularTrainerMovesets(true);
+        new TrainerMovesetRandomizer(romHandler, s, new Random(20260712L)).randomizeTrainerMovesets();
+
+        List<Move> allMoves = romHandler.getMoves();
+        List<String> violations = new ArrayList<>();
+        Map<Integer, Integer> moveCounts = new HashMap<>();
+        int tpCount = 0;
+        int printed = 0;
+        int resetCount = 0;   // empty-pool mons handed back to the game for their natural level-up moveset
+        int naturalCount = 0; // moveless mons in trainers with no custom moves (e.g. first-rival) -> game fills them
+
+        for (Trainer tr : romHandler.getTrainers()) {
+            boolean printThis = printed < SAMPLE_MOVESETS_PER_ROM;
+            for (TrainerPokemon tp : tr.getPokemon()) {
+                tpCount++;
+                Species pk = tp.getSpecies();
+                int ability = safeAbility(romHandler, tp);
+                Set<Integer> movesThisMon = new HashSet<>();
+                int nonZero = 0;
+                StringBuilder line = new StringBuilder("  [" + tierOf(tr) + "] L" + tp.getLevel() + " "
+                        + pk.getName() + " (" + typeStr(pk) + "): ");
+
+                for (int moveID : tp.getMoves()) {
+                    if (moveID == 0) {
+                        continue;
+                    }
+                    nonZero++;
+                    moveCounts.merge(moveID, 1, Integer::sum);
+                    String moveName = allMoves.get(moveID).name;
+                    line.append(moveName).append(' ');
+                    if (!movesThisMon.add(moveID)) {
+                        violations.add(romName + ": duplicate move " + moveName + " on " + pk.getName());
+                    }
+                    String weather = weatherRedundancy(moveID, pk, ability);
+                    if (weather != null) {
+                        violations.add(romName + ": " + weather);
+                    }
+                    if (moveID == MoveIDs.trickRoom && pk.getSpeed() > 60) {
+                        violations.add(romName + ": Trick Room on fast " + pk.getName() + " (spe " + pk.getSpeed() + ")");
+                    }
+                }
+                // Sleep Talk and Snore are useless without Rest, so they may only appear alongside it.
+                if (!movesThisMon.contains(MoveIDs.rest)) {
+                    if (movesThisMon.contains(MoveIDs.sleepTalk)) {
+                        violations.add(romName + ": Sleep Talk without Rest on " + pk.getName());
+                    }
+                    if (movesThisMon.contains(MoveIDs.snore)) {
+                        violations.add(romName + ": Snore without Rest on " + pk.getName());
+                    }
+                }
+                // Spit Up and Swallow consume Stockpile counters, so they may only appear alongside Stockpile.
+                if (!movesThisMon.contains(MoveIDs.stockpile)) {
+                    if (movesThisMon.contains(MoveIDs.spitUp)) {
+                        violations.add(romName + ": Spit Up without Stockpile on " + pk.getName());
+                    }
+                    if (movesThisMon.contains(MoveIDs.swallow)) {
+                        violations.add(romName + ": Swallow without Stockpile on " + pk.getName());
+                    }
+                }
+                if (nonZero == 0) {
+                    // A mon with empty move slots is only genuinely moveless in-game when its trainer writes
+                    // custom moves yet this mon is neither reset nor given any. When the trainer has no custom
+                    // moves at all - e.g. the intentionally-excluded first-rival battle - the game supplies the
+                    // natural level-up moveset, so that is expected, not a regression.
+                    if (tp.isResetMoves()) {
+                        resetCount++;
+                    } else if (tr.pokemonHaveCustomMoves()) {
+                        violations.add(romName + ": moveless " + pk.getName() + " in a custom-move trainer (no moves, no reset)");
+                    } else {
+                        naturalCount++;
+                    }
+                }
+                if (printThis) {
+                    System.out.println(line);
+                }
+            }
+            if (printThis && !tr.getPokemon().isEmpty()) {
+                printed++;
+            }
+        }
+
+        int finalTp = tpCount;
+        for (Map.Entry<Integer, Integer> e : moveCounts.entrySet()) {
+            double rate = (double) e.getValue() / (double) finalTp;
+            if (rate >= UBIQUITOUS_RATE) {
+                violations.add(String.format("%s: '%s' is ubiquitous (%.1f%% of mons)",
+                        romName, allMoves.get(e.getKey()).name, rate * 100));
+            }
+        }
+        System.out.printf("  -> %d trainer Pokemon, %d distinct moves, %d violation(s)%s%s%n",
+                tpCount, moveCounts.size(), violations.size(),
+                resetCount > 0 ? " (" + resetCount + " empty-pool mon(s) reset to natural moveset)" : "",
+                naturalCount > 0 ? " (" + naturalCount + " excluded/no-custom-move mon(s) -> natural moveset)" : "");
+        return violations;
+    }
+
+    // Returns a violation description if this weather move is redundant on the Pokemon, else null.
+    private String weatherRedundancy(int moveID, Species pk, int ability) {
+        boolean ok = switch (moveID) {
+            case MoveIDs.rainDance -> hasType(pk, Type.WATER) || RAIN_ABILITIES.contains(ability);
+            case MoveIDs.sunnyDay -> hasType(pk, Type.FIRE) || SUN_ABILITIES.contains(ability);
+            case MoveIDs.sandstorm -> hasType(pk, Type.ROCK) || hasType(pk, Type.GROUND)
+                    || hasType(pk, Type.STEEL) || SAND_ABILITIES.contains(ability);
+            case MoveIDs.hail -> hasType(pk, Type.ICE) || HAIL_ABILITIES.contains(ability);
+            default -> true;
+        };
+        if (ok) {
+            return null;
+        }
+        String move = switch (moveID) {
+            case MoveIDs.rainDance -> "Rain Dance";
+            case MoveIDs.sunnyDay -> "Sunny Day";
+            case MoveIDs.sandstorm -> "Sandstorm";
+            default -> "Hail";
+        };
+        return "redundant " + move + " on " + pk.getName() + " (" + typeStr(pk) + "), ability " + ability;
+    }
+
+    private static int safeAbility(RomHandler romHandler, TrainerPokemon tp) {
+        try {
+            return romHandler.abilitiesPerSpecies() != 0 ? romHandler.getAbilityForTrainerPokemon(tp) : 0;
+        } catch (RuntimeException e) {
+            return 0;
+        }
+    }
+
+    private static boolean hasType(Species pk, Type type) {
+        return pk.getPrimaryType(false) == type || pk.getSecondaryType(false) == type;
+    }
+
+    private static String typeStr(Species pk) {
+        Type t2 = pk.getSecondaryType(false);
+        return pk.getPrimaryType(false) + (t2 == null ? "" : "/" + t2);
+    }
+
+    private static String tierOf(Trainer tr) {
+        if (tr.isBoss()) {
+            return "BOSS";
+        }
+        if (tr.isImportant()) {
+            return "IMP ";
+        }
+        return "REG ";
+    }
+
+    private RomHandler tryLoad(String path) {
+        for (Generation gen : new HashSet<>(Generation.GAME_TO_GENERATION.values())) {
+            try {
+                RomHandler.Factory factory = gen.createFactory();
+                if (factory.isLoadable(path)) {
+                    RomHandler rh = factory.create();
+                    rh.loadRom(path);
+                    return rh;
+                }
+            } catch (Throwable e) {
+                System.out.println("  [gen " + gen.getNumber() + " load error for " + new File(path).getName()
+                        + "]: " + e.getClass().getSimpleName() + ": " + e.getMessage());
+            }
+        }
+        return null;
+    }
+}

--- a/romio/src/main/java/com/uprfvx/romio/constants/GlobalConstants.java
+++ b/romio/src/main/java/com/uprfvx/romio/constants/GlobalConstants.java
@@ -178,6 +178,70 @@ public class GlobalConstants {
             MoveIDs.spitUp, MoveIDs.swallow, MoveIDs.dreamEater, MoveIDs.nightmare
     );
 
+    // --- Pokemon Showdown teambuilder move-viability lists -------------------------------------------------
+    // Source: smogon/pokemon-showdown-client, play.pokemonshowdown.com/src/battle-dex-search.ts
+    //         (BattleMoveSearch.moveIsNotUseless + its GOOD_/BAD_ constants). MIT-licensed, GPL-compatible.
+    // These mirror how Showdown splits a Pokemon's movepool into "Moves" vs "Usually useless moves".
+    // Gen 8/9 (and Legends/Let's-Go-only) moves from the originals are omitted, as this randomizer's ROM
+    // handlers only reach Gen 7, so those move IDs can never appear in a supported ROM.
+
+    // Status moves considered worth running (everything else in the Status category is "usually useless").
+    public static final List<Integer> goodStatusMoves = Arrays.asList(
+            MoveIDs.acidArmor, MoveIDs.agility, MoveIDs.aromatherapy, MoveIDs.auroraVeil, MoveIDs.autotomize,
+            MoveIDs.banefulBunker, MoveIDs.batonPass, MoveIDs.bellyDrum, MoveIDs.bulkUp, MoveIDs.calmMind,
+            MoveIDs.clangorousSoul, MoveIDs.coil, MoveIDs.cottonGuard, MoveIDs.courtChange, MoveIDs.curse,
+            MoveIDs.defog, MoveIDs.destinyBond, MoveIDs.detect, MoveIDs.disable, MoveIDs.dragonDance,
+            MoveIDs.encore, MoveIDs.extremeEvoboost, MoveIDs.geomancy, MoveIDs.glare, MoveIDs.haze,
+            MoveIDs.healBell, MoveIDs.healingWish, MoveIDs.healOrder, MoveIDs.heartSwap, MoveIDs.honeClaws,
+            MoveIDs.kingsShield, MoveIDs.leechSeed, MoveIDs.lightScreen, MoveIDs.lovelyKiss, MoveIDs.lunarDance,
+            MoveIDs.magicCoat, MoveIDs.maxGuard, MoveIDs.memento, MoveIDs.milkDrink, MoveIDs.moonlight,
+            MoveIDs.morningSun, MoveIDs.nastyPlot, MoveIDs.noRetreat, MoveIDs.obstruct,
+            MoveIDs.painSplit, MoveIDs.partingShot, MoveIDs.perishSong, MoveIDs.protect, MoveIDs.quiverDance,
+            MoveIDs.recover, MoveIDs.reflect, MoveIDs.reflectType, MoveIDs.rest, MoveIDs.roar,
+            MoveIDs.rockPolish, MoveIDs.roost, MoveIDs.shellSmash, MoveIDs.shiftGear, MoveIDs.shoreUp,
+            MoveIDs.slackOff, MoveIDs.sleepPowder, MoveIDs.sleepTalk, MoveIDs.softBoiled, MoveIDs.spikes,
+            MoveIDs.spikyShield, MoveIDs.spore, MoveIDs.stealthRock, MoveIDs.stickyWeb, MoveIDs.strengthSap,
+            MoveIDs.substitute, MoveIDs.switcheroo, MoveIDs.swordsDance, MoveIDs.synthesis, MoveIDs.tailGlow,
+            MoveIDs.tailwind, MoveIDs.taunt, MoveIDs.thunderWave, MoveIDs.toxic, MoveIDs.transform,
+            MoveIDs.trick, MoveIDs.whirlwind, MoveIDs.willOWisp, MoveIDs.wish, MoveIDs.yawn
+    );
+
+    // Sub-75 base power attacks that are still worth running (utility/priority/pivot/etc.).
+    public static final List<Integer> goodWeakMoves = Arrays.asList(
+            MoveIDs.accelerock, MoveIDs.acrobatics, MoveIDs.avalanche, MoveIDs.bonemerang, MoveIDs.bouncyBubble,
+            MoveIDs.bulletPunch, MoveIDs.buzzyBuzz, MoveIDs.circleThrow, MoveIDs.clearSmog, MoveIDs.doubleIronBash,
+            MoveIDs.dragonDarts, MoveIDs.dragonTail, MoveIDs.drainingKiss, MoveIDs.endeavor, MoveIDs.facade,
+            MoveIDs.fireFang, MoveIDs.flipTurn, MoveIDs.freezeDry, MoveIDs.frustration, MoveIDs.gearGrind,
+            MoveIDs.gigaDrain, MoveIDs.grassKnot, MoveIDs.gyroBall, MoveIDs.iceFang, MoveIDs.iceShard,
+            MoveIDs.icicleSpear, MoveIDs.knockOff, MoveIDs.lowKick, MoveIDs.machPunch, MoveIDs.naturesMadness,
+            MoveIDs.nightShade, MoveIDs.nuzzle, MoveIDs.pikaPapow, MoveIDs.psychoCut, MoveIDs.pursuit,
+            MoveIDs.quickAttack, MoveIDs.rapidSpin, MoveIDs.rockBlast, MoveIDs.scorchingSands, MoveIDs.seismicToss,
+            MoveIDs.shadowClaw, MoveIDs.shadowSneak, MoveIDs.sizzlySlide, MoveIDs.storedPower, MoveIDs.stormThrow,
+            MoveIDs.suckerPunch, MoveIDs.superFang, MoveIDs.surgingStrikes, MoveIDs.tailSlap, MoveIDs.tripleAxel,
+            MoveIDs.uTurn, MoveIDs.vacuumWave, MoveIDs.veeveeVolley, MoveIDs.voltSwitch, MoveIDs.waterShuriken,
+            MoveIDs.weatherBall, MoveIDs.returnTheMoveNotTheKeyword
+    );
+
+    // 75+ base power attacks that are nonetheless "usually useless" (recharge, bad accuracy/recoil, gimmicks).
+    public static final List<Integer> badStrongMoves = Arrays.asList(
+            MoveIDs.belch, MoveIDs.burnUp, MoveIDs.crushClaw, MoveIDs.dragonRush, MoveIDs.dreamEater,
+            MoveIDs.eggBomb, MoveIDs.firePledge, MoveIDs.flyingPress, MoveIDs.futureSight, MoveIDs.grassPledge,
+            MoveIDs.hyperBeam, MoveIDs.hyperFang, MoveIDs.hyperspaceHole, MoveIDs.jawLock, MoveIDs.landsWrath,
+            MoveIDs.megaKick, MoveIDs.megaPunch, MoveIDs.mistyExplosion, MoveIDs.muddyWater, MoveIDs.nightDaze,
+            MoveIDs.pollenPuff, MoveIDs.rockClimb, MoveIDs.selfDestruct, MoveIDs.shellTrap, MoveIDs.skyUppercut,
+            MoveIDs.slam, MoveIDs.strength, MoveIDs.submission, MoveIDs.synchronoise, MoveIDs.takeDown,
+            MoveIDs.thrash, MoveIDs.uproar, MoveIDs.waterPledge
+    );
+
+    // Moves that are specifically good in double battles (Showdown only whitelists these in the doubles builder).
+    public static final List<Integer> goodDoublesMoves = Arrays.asList(
+            MoveIDs.allySwitch, MoveIDs.bulldoze, MoveIDs.coaching, MoveIDs.electroweb, MoveIDs.fakeTears,
+            MoveIDs.fling, MoveIDs.followMe, MoveIDs.healPulse, MoveIDs.helpingHand, MoveIDs.jungleHealing,
+            MoveIDs.lifeDew, MoveIDs.muddyWater, MoveIDs.pollenPuff, MoveIDs.psychUp, MoveIDs.ragePowder,
+            MoveIDs.safeguard, MoveIDs.skillSwap, MoveIDs.snipeShot, MoveIDs.wideGuard, MoveIDs.decorate,
+            MoveIDs.snarl
+    );
+
     // Because some base formes are non-obvious, they deserve forme suffixes to explain themselves
     public static final Map<Integer, String> baseFormesWithFormeSuffixes = Map.of(
             SpeciesIDs.wormadam, "-Plant",


### PR DESCRIPTION
Replace the "draw 4 from a synergy-weighted pool" model with explicit role slots: STAB attack, coverage attack (hits what STAB is walled by), status (bosses/important only), then synergy-weighted wildcard fills. Any unfillable slot falls back to the next-best damaging move.

- Strip situational-redundant status moves (weather the mon can't use, Trick Room on fast mons) up front; gate stat boosts on a matching attacker; enforce enabler dependencies (Sleep Talk/Snore need Rest, Spit Up/Swallow need Stockpile) across the final set.
- Empty-pool mons reset to their natural level-up moveset instead of being left moveless.
- Add Pokemon Showdown-derived move-viability lists (goodStatusMoves, goodWeakMoves, badStrongMoves, goodDoublesMoves) to GlobalConstants.
- Add ROM-driven BetterMovesetsRandomizerTest asserting the redesign's invariants; verified across 24 ROMs (gens 1-7, ~40k trainer Pokemon) with zero violations.

If you want to contribute something to the codebase, we recommended to create an issue for it first (using the `Contribution Idea` template). This way, we can discuss how to accomplish this, and possibly whether it is a good fit for the Randomizer. 

In case you have already implemented your idea in code, you should still create a `Contribution Idea` issue, to ensure every Pull Request has an associated Issue.