### PR TITLE
Fix randomization of TM field items

### DIFF
--- a/random/src/main/java/com/uprfvx/random/randomizers/ItemRandomizer.java
+++ b/random/src/main/java/com/uprfvx/random/randomizers/ItemRandomizer.java
@@ -106,6 +106,7 @@ public class ItemRandomizer extends Randomizer {
 
         tms.clear();
         tms.addAll(newTMs);
+        Collections.shuffle(tms, random);
     }
 
     /**


### PR DESCRIPTION
Fixes #248

The new TMs are selected randomly and inserted into a HashSet. The position of each element in the set is computed with the table length and hash code of the element. For a given game, the length of the set is always the same. This is a problem because this means the new TMs will have a sequence based on their hash codes. This sequence is then appended to the (empty) original TM list, resulting in a non-random ordering.

In a game with less field TMs, like Emerald, this bug is harder to perceive because there is a lower proportion of field TMs compared to total TMs, so the random selection from allTMs masks the sequence somewhat. However, a game with a lot of field TMs like B/W 2 will make the sequence very obvious.

The issue is fixed by shuffling tms after newTMs is appended, so the TM distribution is no longer affected by the HashSet ordering.